### PR TITLE
Separated the stacks to enable CFN parameters

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -24,19 +24,19 @@ The scripts will update the Lambda function zip file or Lambda layer zip file re
 
 To prepare your environment for CDK usage, run 
 
-    cdk bootstrap -c elbTargetGroupArn="arn:aws:elasticloadbalancing:SOME_REGION:SOME_ACCOUNT_NUM:targetgroup/AppServerATG/090a4ba28ada9d48"
+    cdk bootstrap -c elbTargetGroupArn="REPLACE_WITH_YOUR_ELBTARGETGROUP_ARN"
 
 To synthesize the CloudFormation templates:
 
-    cdk synth -c elbTargetGroupArn="arn:aws:elasticloadbalancing:SOME_REGION:SOME_ACCOUNT_NUM:targetgroup/AppServerATG/090a4ba28ada9d48"
+    cdk synth -c elbTargetGroupArn="REPLACE_WITH_YOUR_ELBTARGETGROUP_ARN"
 
 Replace the *elbTargetGroupArn* context parameter value with the ARN for your desired Target Group. The stack uses the elbTargetGroupArn parameter value to generate the correct CF template. As a prerequisite, you must have Application Load Balancers with appropriate Target Groups in your AWS environment.
 
-To deploy the stacks:
+To deploy the ALBMonitorStack:
 
-    cdk deploy ALBMonitorStack -c elbTargetGroupArn="arn:aws:elasticloadbalancing:SOME_REGION:SOME_ACCOUNT_NUM:targetgroup/AppServerATG/090a4ba28ada9d48" --parameters elbArn="arn:aws:elasticloadbalancing:SOME_REGION:SOME_ACCOUNT_NUM:loadbalancer/app/AgentPortalALB/bb6bb42b08f94c0b" --parameters elbListenerArn="arn:aws:elasticloadbalancing:SOME_REGION:SOME_ACCOUNT_NUM:listener/app/AgentPortalALB/bb6bb42b08f94c0b/b3784a6b090b3696"
+    cdk deploy ALBMonitorStack -c elbTargetGroupArn="REPLACE_WITH_YOUR_ELBTARGETGROUP_ARN" --parameters elbArn="REPLACE_WITH_YOUR_ELB_ARN" --parameters elbListenerArn="REPLACE_WITH_YOUR_ELBLISTENER_ARN"
 
-    cdk deploy ALBCloudWatchStack -c elbTargetGroupArn="arn:aws:elasticloadbalancing:SOME_REGION:SOME_ACCOUNT_NUM:targetgroup/AppServerATG/090a4ba28ada9d48" --parameters cwAlarmThreshold=500
+Note: Deployment of ALBMonitorStack will output the ARN of the Lambda provide to ALBCloudWatchStack.
 
 Provide the appropriate parameter values. The follow parameters are required:
 
@@ -44,9 +44,24 @@ Provide the appropriate parameter values. The follow parameters are required:
     elbListenerARN - ARN for the ALB Listener to update for shedding/restoring
 
 The following parameters are optional:
+    elbShedPercent - Percentage to shed expressed as an integer. Default: 5
+    maxElbShedPercent - aximum allowable load to shed from ELB. Default: 100
+    elbRestorePercent - Percentage to restore expressed as an integer. Default: 5
+    shedMesgDelaySec - Number of seconds to delay shed messages. Default: 60
+    restoreMesgDelaySec - Number of seconds to delay restore messages. Default: 120
 
+To deploy the ALBCloudWatchStack:
+
+    cdk deploy ALBCloudWatchStack -c elbTargetGroupArn="REPLACE_WITH_YOUR_ELBTARGETGROUP_ARN" --parameters cwAlarmLambdaArn="REPLACE_WITH_YOUR_LAMBDA_ARN" --
+
+Provide the appropriate parameter values. The follow parameters are required:
+    cwAlarmLambdaArn - ARN for Lambda to fire when in Alarm state. 
+
+The following parameters are optional:
     cwAlarmNamespace - The namespace for the CloudWatch (CW) metric (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/viewing_metrics_with_cloudwatch.html). Default: AWS/ApplicationELB
     cwAlarmMetricName - The name of the CW metric. Default: RequestCountPerTarget
-    cwAlarmMetricStatistic - Function to use for aggregating the statistic. Default: Average
+    cwAlarmMetricStat - Function to use for aggregating the statistic. Default: Average
     cwAlarmThreshold - Threshold value that triggers an alarm for the metric. Default: 500
     cwAlarmPeriods - The evaluation period for the alarm. Default: 3.
+
+

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -9,13 +9,14 @@ from aws_cdk import core as cdk
 # being updated to use `cdk`.  You may delete this import if you don't need it.
 from aws_cdk import core
 
-from cdk.alb_monitor_stack import ALBMonitorStack, ALBCloudWatchStack
-
+from cdk.alb_monitor_stack import ALBMonitorStack
+from cdk.alb_cloudwatch_stack import ALBCloudWatchStack
 
 app = core.App()
 
+
 alb_monitor_stack = ALBMonitorStack(app, "ALBMonitorStack")
-ALBCloudWatchStack(app, 'ALBCloudWatchStack',
-                   alb_monitor_stack.alb_alarm_lambda)
+
+alb_cloudwatch_stack = ALBCloudWatchStack(app, 'ALBCloudWatchStack')
 
 app.synth()

--- a/cdk/cdk/alb_cloudwatch_stack.py
+++ b/cdk/cdk/alb_cloudwatch_stack.py
@@ -1,0 +1,78 @@
+import pathlib
+
+# For consistency with other languages, `cdk` is the preferred import name for
+# the CDK's core module.  The following line also imports it as `core` for use
+# with examples from the CDK Developer's Guide, which are in the process of
+# being updated to use `cdk`.  You may delete this import if you don't need it.
+from aws_cdk import aws_cloudwatch, aws_events, aws_events_targets, aws_iam, aws_lambda
+from aws_cdk import aws_lambda_event_sources, aws_sqs
+from aws_cdk import core
+from aws_cdk import core as cdk
+
+class ALBCloudWatchStack(cdk.Stack):
+    
+    def __init__(self, scope: cdk.Construct, construct_id: str,  **kwargs
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        elb_target_group_arn = self.node.try_get_context('elbTargetGroupArn')
+
+        if elb_target_group_arn is None:
+            raise ValueError(
+                'Must specify context parameter elbTargetGroupArn. Usage: cdk <COMMAND> -c elbTargetGroupArn ' +
+                '<ELB_TARGET_GROUP_ARN>')
+
+        alb_sqs_alarm_lambda = self.node.try_get_context('')
+
+        target_group_dimension = elb_target_group_arn[elb_target_group_arn.find(
+            'targetgroup'):len(elb_target_group_arn)]
+
+        cw_alarm_lambda_arn = core.CfnParameter(
+            self, 'cwAlarmLambdaArn', type='String', description='ARN for Lambda to fire when in Alarm')
+        cw_alarm_namespace = core.CfnParameter(
+            self, 'cwAlarmNamespace', type='String', description='Namespace for alarm metric', default='AWS/ApplicationELB')
+        cw_alarm_metric_name = core.CfnParameter(
+            self, 'cwAlarmMetricName', type='String', description='Metric to use for alarm', default='RequestCountPerTarget')
+        # Cannot use CfnParameter due to issue with CDK construct validation. Metric construct requires value to
+        # be a specific value (e.g. sum, average, etc) as opposed to a value pulled from CfnParameter
+        #
+        # cw_alarm_metric_stat = core.CfnParameter(
+        #    self, 'cwAlarmMetricStat', type='String', description='Statistic for the alarm e.g. sum, averge', default='Sum')
+        cw_alarm_threshold = core.CfnParameter(
+            self, 'cwAlarmThreshold', type='Number', description='Threshold for alarm', default=500)
+        cw_alarm_periods = core.CfnParameter(
+            self, 'cwAlarmPeriods', type='Number', description='Num of periods for alarm', default=3)
+
+        # The evaluation period for the alarm will be 60s/1m.
+        request_count_per_target_metric = aws_cloudwatch.Metric(
+            namespace=cw_alarm_namespace.value_as_string,
+            metric_name=cw_alarm_metric_name.value_as_string,
+            dimensions={
+                "TargetGroup": target_group_dimension
+            },
+            statistic='sum',
+            period=cdk.Duration.minutes(1)
+        )
+
+        cw_alarm = aws_cloudwatch.Alarm(
+            self, 'ALBTargetGroupAlarm', alarm_name='ALBTargetGroupAlarm',
+            alarm_description='Alarm for RequestCountPerTarget',
+            metric=request_count_per_target_metric, threshold=cw_alarm_threshold.value_as_number,
+            evaluation_periods=cw_alarm_periods.value_as_number,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD)
+
+        event_rule = aws_events.Rule(
+            self, 'ALBTargetGroupAlarmEventRule', rule_name='ALBTargetGroupAlarmEventRule',
+            description='EventBridge rule for ALB target')
+
+        event_rule.add_event_pattern(
+            source=['aws.cloudwatch'], detail_type=['CloudWatch Alarm State Change'], resources=[cw_alarm.alarm_arn])
+
+
+        alb_sqs_alarm_lambda = aws_lambda.Function.from_function_arn(
+            self,
+            id="alb_sqs_alarm_lambda",
+            function_arn=cw_alarm_lambda_arn.value_as_string)
+
+        event_rule.add_target(
+            aws_events_targets.LambdaFunction(alb_sqs_alarm_lambda))


### PR DESCRIPTION
Parameters for the Cloud Watch Alarm Stack were unable to be used. Logically separating the dependencies between the stacks enabled the parameters to be separately passed in two different _cdk deploy_ commands.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
