### PR TITLE
Supply inline_policies as Mapping[str, PolicyDocument]

### DIFF
--- a/cdk/cdk/alb_monitor_stack.py
+++ b/cdk/cdk/alb_monitor_stack.py
@@ -107,9 +107,9 @@ class ALBMonitorStack(cdk.Stack):
                     self, id='elb_full',
                     managed_policy_arn='arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess')
             ],
-            inline_policies=[
-                aws_iam.PolicyDocument.from_json(inline_policy_json_sqs),
-                aws_iam.PolicyDocument.from_json(inline_policy_json_logs)]
+            inline_policies={
+                "sqs": aws_iam.PolicyDocument.from_json(inline_policy_json_sqs),
+                "logs": aws_iam.PolicyDocument.from_json(inline_policy_json_logs)}
         )
 
 
@@ -187,9 +187,9 @@ class ALBMonitorStack(cdk.Stack):
                     self, id='elb_full2',
                     managed_policy_arn='arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess')
             ],
-            inline_policies=[
-                aws_iam.PolicyDocument.from_json(inline_policy_json_sqs),
-                aws_iam.PolicyDocument.from_json(inline_policy_json_logs)]
+            inline_policies={
+                "sqs": aws_iam.PolicyDocument.from_json(inline_policy_json_sqs),
+                "logs": aws_iam.PolicyDocument.from_json(inline_policy_json_logs)}
         )
 
         # The code for the ALB Alarm Check Queue Lambda


### PR DESCRIPTION
*Description of changes:*

Supply `inline_policies` arguments as a `typing.Optional[typing.Mapping[builtins.str, PolicyDocument]]`, as it is typed to be. Previously it was provided as array, but this likely only worked on older version by accident.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
